### PR TITLE
Add CPU pinning support

### DIFF
--- a/environments/numa.yaml
+++ b/environments/numa.yaml
@@ -1,0 +1,9 @@
+# A Heat environment file which can be used to enable
+# Numa on compute nodes
+resource_registry:
+  OS::TripleO::ComputeExtraConfigPre: ../puppet/extraconfig/pre_deploy/compute/numa.yaml
+
+parameter_defaults:
+  #LibvirtCPUPinSet: '1'
+  NovaImage: 'overcloud-full'
+  BlockStorageImage: 'overcloud-full'

--- a/puppet/extraconfig/pre_deploy/compute/numa.yaml
+++ b/puppet/extraconfig/pre_deploy/compute/numa.yaml
@@ -1,0 +1,36 @@
+heat_template_version: 2015-04-30
+
+description: Compute node hieradata for NUMA configuration
+
+parameters:
+  server:
+    description: ID of the compute node to apply this config to
+    type: string
+  LibvirtCPUPinSet:
+    description: A list or range of physical CPU cores to reserve for virtual machine processes
+    type: string
+
+resources:
+  ComputeNumaConfig:
+    type: OS::Heat::StructuredConfig
+    properties:
+      group: os-apply-config
+      config:
+        hiera:
+          datafiles:
+            numa:
+              mapped_data:
+                nova::compute::vcpu_pin_set: {get_input: vcpu_pin_set}
+
+  ComputeNumaDeployment:
+    type: OS::Heat::StructuredDeployment
+    properties:
+      config: {get_resource: ComputeNumaConfig}
+      server: {get_param: server}
+      input_values:
+        vcpu_pin_set: {get_param: LibvirtCPUPinSet}
+
+outputs:
+  deploy_stdout:
+    description: Output of the extra hiera data deployment
+    value: {get_attr: [ComputeNumaDeployment, deploy_stdout]}


### PR DESCRIPTION
Enable libvirt CPU pinning by setting the LibvirtCPUPinSet parameter
in environments/numa.yaml and adding it to the list of deploy
templates.

This will also change the compute image name, so that isolcpus
can be set for that image. This is done via the deploy script
as it requires setting a kernel parameter which is done via
modification of grub.conf in the image for compute nodes.
