### PR TITLE
Make numa preconfig optional

### DIFF
--- a/environments/numa.yaml
+++ b/environments/numa.yaml
@@ -1,7 +1,7 @@
 # A Heat environment file which can be used to enable
 # Numa on compute nodes
-resource_registry:
-  OS::TripleO::ComputeExtraConfigPre: ../puppet/extraconfig/pre_deploy/compute/numa.yaml
+#resource_registry:
+#  {numa}
 
 parameter_defaults:
   #LibvirtCPUPinSet: '1'


### PR DESCRIPTION
The numa environment file is used to specify alternative images,
and will currently fail if the libvirtpin option is not set, but
other performance options are. This patch makes libvirt pinning
disabled by default, so that alternative images can be provided
without enabling pinning.
