### PR TITLE
Add collectd service to all nodes

### DIFF
--- a/puppet/manifests/overcloud_compute.pp
+++ b/puppet/manifests/overcloud_compute.pp
@@ -20,6 +20,12 @@ create_resources(kmod::load, hiera('kernel_modules'), {})
 create_resources(sysctl::value, hiera('sysctl_settings'), {})
 Exec <| tag == 'kmod::load' |>  -> Sysctl <| |>
 
+exec { 'collect-restart-once':
+  command => 'systemctl restart collectd && touch /root/.collectdconf',
+  creates => '/root/.collectdconf',
+  path    => '/usr/bin:/usr/sbin'
+}
+
 if count(hiera('ntp::servers')) > 0 {
   include ::ntp
 }

--- a/puppet/manifests/overcloud_opendaylight.pp
+++ b/puppet/manifests/overcloud_opendaylight.pp
@@ -15,6 +15,12 @@
 
 include ::tripleo::packages
 
+exec { 'collect-restart-once':
+  command => 'systemctl restart collectd && touch /root/.collectdconf',
+  creates => '/root/.collectdconf',
+  path    => '/usr/bin:/usr/sbin'
+}
+
 if count(hiera('ntp::servers')) > 0 {
   include ::ntp
 }


### PR DESCRIPTION
Collectd is configured to start on boot, but the network interface
for pushing stats to the undercloud won't be available until after
os-net-config. Metrics will still be collected before this time,
but won't be pushed until the service is restarted by puppet.
