### PR TITLE
Add notifier topic to ceilometer

### DIFF
--- a/puppet/manifests/overcloud_controller.pp
+++ b/puppet/manifests/overcloud_controller.pp
@@ -802,6 +802,28 @@ private_network_range: ${private_subnet}/${private_mask}"
   include ::aodh::listener
   include ::aodh::client
 
+$event_pipeline = "---
+sources:
+    - name: event_source
+      events:
+          - \"*\"
+      sinks:
+          - event_sink
+sinks:
+    - name: event_sink
+      transformers:
+      triggers:
+      publishers:
+          - notifier://?topic=alarm.all
+          - notifier://
+"
+
+  file { '/etc/ceilometer/event_pipeline.yaml':
+    ensure  => present,
+    content => $event_pipeline,
+  }
+
+
   # Heat
   class { '::heat' :
     notification_driver => 'messaging',

--- a/puppet/manifests/overcloud_controller_pacemaker.pp
+++ b/puppet/manifests/overcloud_controller_pacemaker.pp
@@ -1451,6 +1451,27 @@ WantedBy=multi-user.target'
     enabled        => false,
   }
 
+$event_pipeline = "---
+sources:
+    - name: event_source
+      events:
+          - \"*\"
+      sinks:
+          - event_sink
+sinks:
+    - name: event_sink
+      transformers:
+      triggers:
+      publishers:
+          - notifier://?topic=alarm.all
+          - notifier://
+"
+
+  file { '/etc/ceilometer/event_pipeline.yaml':
+    ensure  => present,
+    content => $event_pipeline,
+  }
+
   class { '::congress':
     sync_db => $sync_db,
     manage_service => false,


### PR DESCRIPTION
Aodh requires its alarm topic to be in the ceilometer event
pipeline.
