### PR TITLE
Ensure the Heat Domain parameters before starting heat-engine pcmk se…

### DIFF
--- a/puppet/manifests/overcloud_controller_pacemaker.pp
+++ b/puppet/manifests/overcloud_controller_pacemaker.pp
@@ -1406,6 +1406,15 @@ WantedBy=multi-user.target'
     manage_service => false,
     enabled        => false,
   }
+  # Domain resources will be created at step5 on the pacemaker_master
+  # So we configure heat.conf at step3 and 4 but actually create the domain later.
+  if hiera('step') == 3 or hiera('step') == 4 {
+    class { '::heat::keystone::domain':
+      manage_domain => false,
+      manage_user   => false,
+      manage_role   => false,
+    }
+  }
 
   # httpd/apache and horizon
   # NOTE(gfidente): server-status can be consumed by the pacemaker resource agent


### PR DESCRIPTION
…rvice

Heat needs stack_user_domain_id or stack_user_domain_name config options set
in the heat.conf before starting. The domain itself doesn't need to exist
until a stack is actually created, but the value needs to be there. This patch
ensures that the heat domain parameters are configured before starting the
heat-engine service with Pacemaker at step3 and 4, and at step5,
Pacemaker will start the services and Puppet will create the domains.

Closes-Bug: #1599232

Co-Authored-by: Gael Chamoulaud gchamoul@redhat.com
Co-Authored-by: Emilien Macchi emilien@redhat.com

Change-Id: I9c6ad61208fecde61ee60163dd33b86a709c3802
Signed-off-by: Michael Chapman woppin@gmail.com
