### PR TITLE
Fix neutron host name changes on reboot

### DIFF
--- a/puppet/manifests/overcloud_controller.pp
+++ b/puppet/manifests/overcloud_controller.pp
@@ -387,6 +387,10 @@ if hiera('step') >= 3 {
   include ::neutron::server
   include ::neutron::server::notifications
 
+  neutron_config {
+    'DEFAULT/host': value => $fqdn;
+  }
+
   # If the value of core plugin is set to 'nuage' or'opencontrail' or 'plumgrid',
   # include nuage or opencontrail or plumgrid core plugins
   # else use the default value of 'ml2'

--- a/puppet/manifests/overcloud_controller_pacemaker.pp
+++ b/puppet/manifests/overcloud_controller_pacemaker.pp
@@ -888,6 +888,11 @@ if hiera('step') >= 3 {
   }
 
   include ::neutron::config
+
+  neutron_config {
+    'DEFAULT/host': value => $fqdn;
+  }
+
   class { '::neutron::server' :
     sync_db        => $sync_db,
     manage_service => false,


### PR DESCRIPTION
Neutron agents have a different host name on reboot, causing duplicate
entries in the agent list. This is corrected by locking the host name
to be the fqdn.
