### PR TITLE
Add AggregateInstanceExtraSpecFilter to Scheduler

### DIFF
--- a/environments/numa.yaml
+++ b/environments/numa.yaml
@@ -3,7 +3,7 @@
 
 parameters:
   ExtraConfig:
-    nova::scheduler::filter::scheduler_default_filters: [ RamFilter,ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,PciPassthroughFilter,NUMATopologyFilter ]
+    nova::scheduler::filter::scheduler_default_filters: [ RamFilter,ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecFilter ]
 
 parameter_defaults:
   #LibvirtCPUPinSet: '1'


### PR DESCRIPTION
Numa topologies use this filter to associate a pinning spec
with a host aggregate.

Signed-off-by: Michael Chapman woppin@gmail.com
