### PR TITLE
Support glance location-add

### DIFF
--- a/puppet/hieradata/controller.yaml
+++ b/puppet/hieradata/controller.yaml
@@ -81,6 +81,7 @@ swift::proxy::account_autocreate: true
 # glance
 glance::api::pipeline: 'keystone'
 glance::api::show_image_direct_url: true
+glance::api::show_multiple_locations: true
 glance::registry::pipeline: 'keystone'
 glance::backend::swift::swift_store_create_container_on_put: true
 glance_file_pcmk_directory: '/var/lib/glance/images'


### PR DESCRIPTION
Glance's location-add command requires an additional config
option to function correctly with the v2 api, since locations
became a resource.
