### PR TITLE
Use networking-odl v1 driver in bgpvpn

### DIFF
--- a/environments/neutron-opendaylight-bgpvpn.yaml
+++ b/environments/neutron-opendaylight-bgpvpn.yaml
@@ -9,8 +9,8 @@ resource_registry:
 
 parameter_defaults:
   NeutronEnableForceMetadata: true
-  NeutronMechanismDrivers: 'opendaylight_v2'
-  NeutronServicePlugins: "odl-router_v2,networking_bgpvpn.neutron.services.plugin.BGPVPNPlugin"
+  NeutronMechanismDrivers: 'opendaylight'
+  NeutronServicePlugins: "odl-router,networking_bgpvpn.neutron.services.plugin.BGPVPNPlugin"
   NeutronNetworkType: 'vxlan'
   ExtraConfig:
     neutron::server::service_providers: [ 'BGPVPN:OpenDaylight:networking_bgpvpn.neutron.services.service_drivers.opendaylight.odl.OpenDaylightBgpvpnDriver:default' ]


### PR DESCRIPTION
This is the version that has been used so far with Fuel in SDNVPN,
v2 is largely untested. This might account for the CI failures in
testcases 4 and 8.

Signed-off-by: Romanos Skiadas <rski@intracom-telecom.com>