### PR TITLE
Enables increasing mariadb open files for noha deployments

### DIFF
--- a/puppet/services/database/mysql.yaml
+++ b/puppet/services/database/mysql.yaml
@@ -23,6 +23,10 @@ parameters:
     description: Configures MySQL max_connections config setting
     type: number
     default: 4096
+  MysqlIncreaseFileLimit:
+    description: Flag to increase MySQL open-files-limit to 16384
+    type: boolean
+    default: true
   MysqlRootPassword:
     type: string
     hidden: true
@@ -80,5 +84,7 @@ outputs:
               '"%{::fqdn_$NETWORK}"'
             params:
               $NETWORK: {get_param: [ServiceNetMap, MysqlNetwork]}
+        tripleo::profile::base::database::mysql:generate_dropin_file_limit:
+          {get_param: MysqlIncreaseFileLimit}
       step_config: |
         include ::tripleo::profile::base::database::mysql


### PR DESCRIPTION
There is currently an issue where the max open files limit is hit with
MariaDB in noha deployments, because it is defaulted to 1024 by system
limits.  In HA deployments the limit is bumped to 16384.  This patch
introduces a flag to be able to increase the limit to 16384 for noHA
deployments.

In the future we should change this to be an integer, and let the
operator decide the setting.  Since this setting is set in a different
path for HA, we would need to implement a change that allows setting
both (ha and nonha) via the same integer param.

Depends-On: Ia0907b2ab6062a93fb9363e39c86535a490fbaf6

Closes-Bug: #1648181
Related-Bug: #1524809

Change-Id: I95393fc798b833a8575afbff03ef74a839565c5e
Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 9db047bd914c3788a1bd6f4b4fe80ee8ebbf1ac7)