### PR TITLE
Adds service for OpenDaylight DPDK

### DIFF
--- a/environments/neutron-opendaylight-l3-dpdk.yaml
+++ b/environments/neutron-opendaylight-l3-dpdk.yaml
@@ -1,0 +1,25 @@
+# A Heat environment that can be used to deploy OpenDaylight with L3 DVR with DPDK support
+resource_registry:
+  OS::TripleO::Services::NeutronOvsAgent: OS::Heat::None
+  OS::TripleO::Services::ComputeNeutronOvsAgent: OS::Heat::None
+  OS::TripleO::Services::ComputeNeutronCorePlugin: OS::Heat::None
+  OS::TripleO::Services::OpenDaylightApi: ../puppet/services/opendaylight-api.yaml
+  OS::TripleO::Services::OpenDaylightOvs: ../puppet/services/opendaylight-ovs-dpdk.yaml
+  OS::TripleO::Services::NeutronL3Agent: OS::Heat::None
+
+parameter_defaults:
+  NeutronEnableForceMetadata: true
+  NeutronMechanismDrivers: 'opendaylight_v2'
+  NeutronServicePlugins: 'odl-router_v2'
+  OpenDaylightEnableL3: "'yes'"
+  #NeutronDpdkCoreList: "'1'"
+  #NeutronDpdkMemoryChannels: "1"
+
+  NeutronDatapathType: "netdev"
+  NeutronVhostuserSocketDir: "/var/run/openvswitch"
+
+  #NeutronDpdkSocketMemory: "1024"
+  #NeutronDpdkDriverType: "uio_pci_generic"
+  #NovaReservedHostMemory: 4096
+  NovaVcpuPinSet: "3"
+

--- a/puppet/services/neutron-ovs-dpdk-agent.yaml
+++ b/puppet/services/neutron-ovs-dpdk-agent.yaml
@@ -18,24 +18,6 @@ parameters:
     description: Mapping of service endpoint -> protocol. Typically set
                  via parameter_defaults in the resource registry.
     type: json
-  NeutronDpdkCoreList:
-    description: List of cores to be used for DPDK Poll Mode Driver
-    type: string
-    constraints:
-      - allowed_pattern: "'[0-9,-]+'"
-  NeutronDpdkMemoryChannels:
-    description: Number of memory channels to be used for DPDK
-    type: string
-    constraints:
-      - allowed_pattern: "[0-9]+"
-  NeutronDpdkSocketMemory:
-    default: ""
-    description: Memory allocated for each socket
-    type: string
-  NeutronDpdkDriverType:
-    default: "vfio-pci"
-    description: DPDK Driver type
-    type: string
   # below parameters has to be set in neutron agent only for compute nodes.
   # as of now there is no other usecase for these parameters except dpdk.
   # should be moved to compute only ovs agent in case of any other usecases.
@@ -65,11 +47,7 @@ outputs:
       config_settings:
         map_merge:
           - get_attr: [NeutronOvsAgent, role_data, config_settings]
-          - neutron::agents::ml2::ovs::enable_dpdk: true
+          - neutron::agents::ml2::ovs::enable_dpdk: false
             neutron::agents::ml2::ovs::datapath_type: {get_param: NeutronDatapathType}
             neutron::agents::ml2::ovs::vhostuser_socket_dir: {get_param: NeutronVhostuserSocketDir}
-            vswitch::dpdk::core_list: {get_param: NeutronDpdkCoreList}
-            vswitch::dpdk::memory_channels: {get_param: NeutronDpdkMemoryChannels}
-            vswitch::dpdk::socket_mem: {get_param: NeutronDpdkSocketMemory}
-            vswitch::dpdk::driver_type: {get_param: NeutronDpdkDriverType}
       step_config: {get_attr: [NeutronOvsAgent, role_data, step_config]}

--- a/puppet/services/opendaylight-ovs-dpdk.yaml
+++ b/puppet/services/opendaylight-ovs-dpdk.yaml
@@ -1,0 +1,75 @@
+heat_template_version: ocata
+
+description: >
+  OpenDaylight OVS DPDK Configuration.
+
+parameters:
+  NeutronDpdkCoreList:
+    description: List of cores to be used for DPDK Poll Mode Driver
+    type: string
+    constraints:
+      - allowed_pattern: "'[0-9,-]+'"
+  NeutronDpdkMemoryChannels:
+    description: Number of memory channels to be used for DPDK
+    type: string
+    constraints:
+      - allowed_pattern: "[0-9]+"
+  NeutronDpdkSocketMemory:
+    default: ""
+    description: Memory allocated for each socket
+    type: string
+  NeutronDpdkDriverType:
+    default: "vfio-pci"
+    description: DPDK Driver type
+    type: string
+  # below parameters has to be set in neutron agent only for compute nodes.
+  # as of now there is no other usecase for these parameters except dpdk.
+  # should be moved to compute only ovs agent in case of any other usecases.
+  NeutronDatapathType:
+    default: ""
+    description: Datapath type for ovs bridges
+    type: string
+  NeutronVhostuserSocketDir:
+    default: ""
+    description: The vhost-user socket directory for OVS
+    type: string
+  EndpointMap:
+    default: {}
+    description: Mapping of service endpoint -> protocol. Typically set
+                 via parameter_defaults in the resource registry.
+    type: json
+  ServiceNetMap:
+    default: {}
+    description: Mapping of service_name -> network name. Typically set
+                 via parameter_defaults in the resource registry.  This
+                 mapping overrides those in ServiceNetMapDefaults.
+    type: json
+  DefaultPasswords:
+    default: {}
+    type: json
+
+resources:
+
+  OpendaylightOvs:
+    type: ./opendaylight-ovs.yaml
+    properties:
+      ServiceNetMap: {get_param: ServiceNetMap}
+      DefaultPasswords: {get_param: DefaultPasswords}
+      EndpointMap: {get_param: EndpointMap}
+
+outputs:
+  role_data:
+    description: Role data for the OpenDaylight DPDK service.
+    value:
+      service_name: opendaylight_ovs_dpdk
+      config_settings:
+        map_merge:
+          - get_attr: [OpendaylightOvs, role_data, config_settings]
+          - neutron::agents::ml2::ovs::enable_dpdk: true
+            neutron::agents::ml2::ovs::datapath_type: {get_param: NeutronDatapathType}
+            neutron::agents::ml2::ovs::vhostuser_socket_dir: {get_param: NeutronVhostuserSocketDir}
+            vswitch::dpdk::core_list: {get_param: NeutronDpdkCoreList}
+            vswitch::dpdk::memory_channels: {get_param: NeutronDpdkMemoryChannels}
+            vswitch::dpdk::socket_mem: {get_param: NeutronDpdkSocketMemory}
+            vswitch::dpdk::driver_type: {get_param: NeutronDpdkDriverType}
+      step_config: {get_attr: [OpendaylightOvs, role_data, step_config]}

--- a/puppet/services/opendaylight-ovs-dpdk.yaml
+++ b/puppet/services/opendaylight-ovs-dpdk.yaml
@@ -1,4 +1,4 @@
-heat_template_version: ocata
+heat_template_version: newton
 
 description: >
   OpenDaylight OVS DPDK Configuration.

--- a/puppet/services/opendaylight-ovs-dpdk.yaml
+++ b/puppet/services/opendaylight-ovs-dpdk.yaml
@@ -4,24 +4,6 @@ description: >
   OpenDaylight OVS DPDK Configuration.
 
 parameters:
-  NeutronDpdkCoreList:
-    description: List of cores to be used for DPDK Poll Mode Driver
-    type: string
-    constraints:
-      - allowed_pattern: "'[0-9,-]+'"
-  NeutronDpdkMemoryChannels:
-    description: Number of memory channels to be used for DPDK
-    type: string
-    constraints:
-      - allowed_pattern: "[0-9]+"
-  NeutronDpdkSocketMemory:
-    default: ""
-    description: Memory allocated for each socket
-    type: string
-  NeutronDpdkDriverType:
-    default: "vfio-pci"
-    description: DPDK Driver type
-    type: string
   # below parameters has to be set in neutron agent only for compute nodes.
   # as of now there is no other usecase for these parameters except dpdk.
   # should be moved to compute only ovs agent in case of any other usecases.
@@ -65,11 +47,7 @@ outputs:
       config_settings:
         map_merge:
           - get_attr: [OpendaylightOvs, role_data, config_settings]
-          - neutron::agents::ml2::ovs::enable_dpdk: true
+          - neutron::agents::ml2::ovs::enable_dpdk: false
             neutron::agents::ml2::ovs::datapath_type: {get_param: NeutronDatapathType}
             neutron::agents::ml2::ovs::vhostuser_socket_dir: {get_param: NeutronVhostuserSocketDir}
-            vswitch::dpdk::core_list: {get_param: NeutronDpdkCoreList}
-            vswitch::dpdk::memory_channels: {get_param: NeutronDpdkMemoryChannels}
-            vswitch::dpdk::socket_mem: {get_param: NeutronDpdkSocketMemory}
-            vswitch::dpdk::driver_type: {get_param: NeutronDpdkDriverType}
       step_config: {get_attr: [OpendaylightOvs, role_data, step_config]}


### PR DESCRIPTION
In order to deploy OpenDaylight with DPDK we need to copy the DPDK
config for OVS done in the neutron-ovs-dpdk service template, without
enabling OVS agent.  This service profile should allow one to override
the OpenDaylightOVS service with this new template, allowing DPDK
support.

Closes-Bug: 1656097

Change-Id: Ie80e38c2a9605d85cdf867a31b6888bfcae69e29
Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 812ba1f79e541ad7452f0abfda69e8205c3af458)