### PR TITLE
Fixes missing ':' with setting hierdata for mariadb limit

### DIFF
--- a/puppet/services/database/mysql.yaml
+++ b/puppet/services/database/mysql.yaml
@@ -84,7 +84,7 @@ outputs:
               '"%{::fqdn_$NETWORK}"'
             params:
               $NETWORK: {get_param: [ServiceNetMap, MysqlNetwork]}
-        tripleo::profile::base::database::mysql:generate_dropin_file_limit:
+        tripleo::profile::base::database::mysql::generate_dropin_file_limit:
           {get_param: MysqlIncreaseFileLimit}
       step_config: |
         include ::tripleo::profile::base::database::mysql


### PR DESCRIPTION
Signed-off-by: Tim Rozet <tdrozet@gmail.com>