### PR TITLE
Barometer service. Installs collectd with Intel Resource Director Technology on Compute nodes.

### DIFF
--- a/environments/enable_barometer.yaml
+++ b/environments/enable_barometer.yaml
@@ -1,0 +1,2 @@
+resource_registry:
+  OS::TripleO::Services::Barometer: ../puppet/services/barometer.yaml

--- a/overcloud-resource-registry-puppet.j2.yaml
+++ b/overcloud-resource-registry-puppet.j2.yaml
@@ -102,6 +102,7 @@ resource_registry:
 
   # services
   OS::TripleO::Services: puppet/services/services.yaml
+  OS::TripleO::Services: puppet/services/barometer.yaml
   OS::TripleO::Services::Apache: puppet/services/apache.yaml
   OS::TripleO::Services::CACerts: puppet/services/ca-certs.yaml
   OS::TripleO::Services::CephMon: OS::Heat::None

--- a/overcloud-resource-registry-puppet.j2.yaml
+++ b/overcloud-resource-registry-puppet.j2.yaml
@@ -102,8 +102,8 @@ resource_registry:
 
   # services
   OS::TripleO::Services: puppet/services/services.yaml
-  OS::TripleO::Services: puppet/services/barometer.yaml
   OS::TripleO::Services::Apache: puppet/services/apache.yaml
+  OS::TripleO::Services::Barometer: OS::Heat::None
   OS::TripleO::Services::CACerts: puppet/services/ca-certs.yaml
   OS::TripleO::Services::CephMon: OS::Heat::None
   OS::TripleO::Services::CephRgw: OS::Heat::None

--- a/puppet/services/barometer.yaml
+++ b/puppet/services/barometer.yaml
@@ -24,6 +24,10 @@ parameters:
     default: {}
     description: the password for the ceilometer service account
     type: string
+  GnocchiPassword:
+    default: {}
+    description: the password for the gnocchi service account
+    type: string
 
 outputs:
   role_data:
@@ -31,9 +35,9 @@ outputs:
     value:
       service_name: barometer
       config_settings:
-        barometer::collectd::public_url: {get_param: [EndpointMap, CeilometerPublic, uri]}
-        barometer::collectd::ceilo_password: {get_param: CeilometerPassword}
-        barometer::collectd::ceilo_username: 'ceilometer'
+        barometer::collectd::collectd_password: {get_param: GnocchiPassword}
+        barometer::collectd::collectd_username: 'gnocchi'
+        barometer::collectd::auth_url: {get_param: [EndpointMap, KeystoneInternal, uri_no_suffix]}
       step_config: |
         include ::tripleo::profile::base::barometer
 

--- a/puppet/services/barometer.yaml
+++ b/puppet/services/barometer.yaml
@@ -1,0 +1,39 @@
+heat_template_version: 2014-10-16
+ 
+description: >
+  Install Barometer (Fastpath Quality Metrics = collectd with RDT) on compute nodes
+ 
+# Note extra parameters can be defined, then passed data via the
+# environment parameter_defaults, without modifying the parent template
+parameters:
+  ServiceNetMap:
+    default: {}
+    description: Mapping of service_name -> network name. Typically set
+                 via parameter_defaults in the resource registry.  This
+                 mapping overrides those in ServiceNetMapDefaults.
+    type: json
+  DefaultPasswords:
+    default: {}
+    type: json
+  EndpointMap:
+    default: {}
+    description: Mapping of service endpoint -> protocol. Typically set
+                 via parameter_defaults in the resource registry.
+    type: json
+  CeilometerPassword:
+    default: {}
+    description: the password for the ceilometer service account
+    type: string
+
+outputs:
+  role_data:
+    description: Role data for Barometer role.
+    value:
+      service_name: barometer
+      config_settings:
+        barometer::collectd::public_url: {get_param: [EndpointMap, CeilometerPublic, uri]}
+        barometer::collectd::ceilo_password: {get_param: CeilometerPassword}
+        barometer::collectd::ceilo_username: 'ceilometer'
+      step_config: |
+        include ::tripleo::profile::base::barometer
+

--- a/roles_data.yaml
+++ b/roles_data.yaml
@@ -107,6 +107,7 @@
   CountDefault: 1
   HostnameFormatDefault: '%stackname%-novacompute-%index%'
   ServicesDefault:
+    - OS::TripleO::Services::Barometer
     - OS::TripleO::Services::CACerts
     - OS::TripleO::Services::CephClient
     - OS::TripleO::Services::CephExternal


### PR DESCRIPTION
Not working: service is enabled (gets registered in resource registry), but barometer class is not called. 
Puppet module is here:
https://github.com/johnhinman/puppet-barometer
Puppet base class:
https://github.com/johnhinman/opnfv-puppet-tripleo/tree/stable/danube/manifests/profile/base
