### PR TITLE
Comment out core pinning hiera settings in VPP service

### DIFF
--- a/puppet/services/vpp.yaml
+++ b/puppet/services/vpp.yaml
@@ -37,7 +37,9 @@ outputs:
       service_name: vpp
       monitoring_subscription: {get_param: MonitoringSubscriptionVpp}
       config_settings:
-        fdio::vpp_cpu_main_core: {get_param: VppCpuMainCore}
-        fdio::vpp_cpu_corelist_workers: {get_param: VppCpuCorelistWorkers}
+        # Core pinning is being set in controller_extraconfig and compute_extraconfig to allow
+        # role specifc settings
+        #fdio::vpp_cpu_main_core: {get_param: VppCpuMainCore}
+        #fdio::vpp_cpu_corelist_workers: {get_param: VppCpuCorelistWorkers}
       step_config: |
         include ::tripleo::profile::base::vpp


### PR DESCRIPTION
Those settings are now set in controller_extraconfig and
novacompute_extraconfig hiera files.